### PR TITLE
Add Dockerized local backend setup and database init flow

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,39 @@
+IF DB_ID('GymApp') IS NULL
+BEGIN
+  CREATE DATABASE GymApp;
+END
+GO
+
+USE GymApp;
+GO
+
+IF OBJECT_ID('dbo.users', 'U') IS NULL
+BEGIN
+  CREATE TABLE dbo.users (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    username NVARCHAR(255) NOT NULL,
+    email NVARCHAR(255) NOT NULL,
+    password_hash NVARCHAR(255) NOT NULL,
+    created_at DATETIME2 NOT NULL CONSTRAINT DF_users_created_at DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2 NOT NULL CONSTRAINT DF_users_updated_at DEFAULT SYSUTCDATETIME()
+  );
+
+  CREATE UNIQUE INDEX UX_users_email ON dbo.users(email);
+  CREATE UNIQUE INDEX UX_users_username ON dbo.users(username);
+END
+GO
+
+IF OBJECT_ID('dbo.refresh_tokens', 'U') IS NULL
+BEGIN
+  CREATE TABLE dbo.refresh_tokens (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    user_id INT NOT NULL,
+    token_hash NVARCHAR(MAX) NOT NULL,
+    expires_at DATETIME2 NOT NULL,
+    revoked BIT NOT NULL CONSTRAINT DF_refresh_tokens_revoked DEFAULT 0,
+    CONSTRAINT FK_refresh_tokens_users FOREIGN KEY (user_id) REFERENCES dbo.users(id)
+  );
+
+  CREATE INDEX IX_refresh_tokens_user_id ON dbo.refresh_tokens(user_id);
+END
+GO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       SQLSERVER_DATABASE: ${SQLSERVER_DATABASE}
     depends_on:
       - sqlserver
+      - db-init
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest
@@ -27,7 +28,19 @@ services:
     volumes:
       - sqlserver-data:/var/opt/mssql
 
+  db-init:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    env_file:
+      - .env.docker
+    depends_on:
+      - sqlserver
+    volumes:
+      - ./db:/db
+    entrypoint: /bin/bash
+    command: -c "until /opt/mssql-tools18/bin/sqlcmd -S sqlserver -U sa -P \"$SA_PASSWORD\" -C -Q 'SELECT 1' > /dev/null 2>&1; do sleep 2; done; /opt/mssql-tools18/bin/sqlcmd -S sqlserver -U sa -P \"$SA_PASSWORD\" -C -d GymApp -i /db/init.sql"
+
 volumes:
   sqlserver-data:
+
 
       


### PR DESCRIPTION
## Summary
- Add Docker support for running the backend and SQL Server locally
- Add database initialization scripting so required tables are created in the Docker database
- Fix backend container configuration for host binding, JWT env usage, and Vitest test discovery

## Notes
- Start the stack with `docker compose --env-file .env.docker up -d`
- SQL Server is exposed on `127.0.0.1,14330`
- The Docker database is now the intended local development database